### PR TITLE
Multi line comments

### DIFF
--- a/src/mysql-runner.Tests/TestStatementReader.cs
+++ b/src/mysql-runner.Tests/TestStatementReader.cs
@@ -1,10 +1,9 @@
+using MySql.Data.MySqlClient;
+using NExpect;
+using NUnit.Framework;
+using PeanutButter.Utils;
 using System;
 using System.Collections.Generic;
-using MySql.Data.MySqlClient;
-using NUnit.Framework;
-using static PeanutButter.RandomGenerators.RandomValueGen;
-using NExpect;
-using PeanutButter.Utils;
 using static NExpect.Expectations;
 
 namespace mysql_runner.tests
@@ -263,7 +262,7 @@ END*/
 
         private StatementReader Create(string filePath, string[] args = null)
         {
-            if(args == null)
+            if (args == null)
                 args = new string[0];
 
             return new StatementReader(filePath, new Options(args));

--- a/src/mysql-runner/Options.cs
+++ b/src/mysql-runner/Options.cs
@@ -22,6 +22,7 @@ namespace mysql_runner
         public bool ShowedHelp { get; set; }
 
         public bool IsValid { get; set; }
+        public bool IncludeMySqlSpecificComments { get; set; }
         private bool ShouldPromptForPassword { get; set; }
         public bool NoProgress { get; set; }
 
@@ -92,8 +93,14 @@ namespace mysql_runner
                 ["--help"] = ShowHelp,
                 ["--prompt"] = SetShouldPromptForPassword,
                 ["--no-progress"] = SetNoProgress,
-                ["--overwrite-existing"] = SetOverwriteExisting
+                ["--overwrite-existing"] = SetOverwriteExisting,
+                ["--include-mysql-comments"] = SetMySqlComments
             };
+
+        private static void SetMySqlComments(Options obj)
+        {
+            obj.IncludeMySqlSpecificComments = true;
+        }
 
         private static void SetOverwriteExisting(Options obj)
         {
@@ -169,16 +176,17 @@ namespace mysql_runner
                 "MySql Runner",
                 "Usage: mysql-runner {options} <file.sql> {<file.sql>...}",
                 "  where options are of:",
-                "  -d {database}         set database (no default)",
-                "  -h {host}             set database host (defaults to localhost)",
-                "  --no-progress         disable progress on quiet operation",
-                "  --overwrite-existing  overwrite any existing target schema, if found",
-                "  -p {password}         set password to log in with (defaults empty)",
-                "  --prompt              will prompt for password",
-                "  -P {port}             set port (defaults to 3306}",
-                "  -s                    stop on error (defaults to carry on)",
-                "  -u {user}             set user to log in with (defaults to root)",
-                "  -v                    verbose operations (echo statements)"
+                "  -d {database}            set database (no default)",
+                "  -h {host}                set database host (defaults to localhost)",
+                "  --no-progress            disable progress on quiet operation",
+                "  --overwrite-existing     overwrite any existing target schema, if found",
+                "  --include-mysql-comments include runnable mysql specific comments ex. /*!50003 create*/",
+                "  -p {password}            set password to log in with (defaults empty)",
+                "  --prompt                 will prompt for password",
+                "  -P {port}                set port (defaults to 3306}",
+                "  -s                       stop on error (defaults to carry on)",
+                "  -u {user}                set user to log in with (defaults to root)",
+                "  -v                       verbose operations (echo statements)"
             }.ForEach(line =>
             {
                 Console.WriteLine(line);

--- a/src/mysql-runner/Program.cs
+++ b/src/mysql-runner/Program.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using MySql.Data.MySqlClient;
+using PeanutButter.Utils;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using MySql.Data.MySqlClient;
-using PeanutButter.Utils;
 
 namespace mysql_runner
 {
@@ -46,7 +46,7 @@ namespace mysql_runner
                     return;
                 }
             }
-            
+
             if (exists)
             {
                 cmd.CommandText = $"drop database `{dbName}`";
@@ -63,7 +63,7 @@ namespace mysql_runner
             {
                 var info = new FileInfo(file);
                 var readBytes = 0L;
-                using var reader = new StatementReader(file);
+                using var reader = new StatementReader(file, opts);
                 string statement;
                 using var disposer = new AutoDisposer();
                 var conn = disposer.Add(ConnectionFactory.Open(connectionStringProvider.ConnectionString));
@@ -152,13 +152,7 @@ namespace mysql_runner
             var percentComplete = (100M * bytesReadSoFar) / totalExpectedBytes;
             var estimatedTotalTime = 100M * (runTime / percentComplete);
             var overwrite = new String(' ', _lastProgressLength);
-            var message = $@"File {file + 1} / {
-                fileCount
-            }    {percentComplete:F1}%    ({
-                HumanReadableTimeFor((int)runTime)
-            } / {
-                HumanReadableTimeFor((int)estimatedTotalTime)
-            }  rem: {HumanReadableTimeFor((int)(estimatedTotalTime - runTime))})";
+            var message = $@"File {file + 1} / {fileCount}    {percentComplete:F1}%    ({HumanReadableTimeFor((int)runTime)} / {HumanReadableTimeFor((int)estimatedTotalTime)}  rem: {HumanReadableTimeFor((int)(estimatedTotalTime - runTime))})";
             _lastProgressLength = message.Length;
             Console.Out.Write($"\r{overwrite}\r{message}");
             Console.Out.Flush();

--- a/src/mysql-runner/Program.cs
+++ b/src/mysql-runner/Program.cs
@@ -152,7 +152,13 @@ namespace mysql_runner
             var percentComplete = (100M * bytesReadSoFar) / totalExpectedBytes;
             var estimatedTotalTime = 100M * (runTime / percentComplete);
             var overwrite = new String(' ', _lastProgressLength);
-            var message = $@"File {file + 1} / {fileCount}    {percentComplete:F1}%    ({HumanReadableTimeFor((int)runTime)} / {HumanReadableTimeFor((int)estimatedTotalTime)}  rem: {HumanReadableTimeFor((int)(estimatedTotalTime - runTime))})";
+            var message = $@"File {file + 1} / {
+                fileCount
+            }    {percentComplete:F1}%    ({
+                HumanReadableTimeFor((int)runTime)
+            } / {
+                HumanReadableTimeFor((int)estimatedTotalTime)
+            }  rem: {HumanReadableTimeFor((int)(estimatedTotalTime - runTime))})";
             _lastProgressLength = message.Length;
             Console.Out.Write($"\r{overwrite}\r{message}");
             Console.Out.Flush();

--- a/src/mysql-runner/StatementReader.cs
+++ b/src/mysql-runner/StatementReader.cs
@@ -106,7 +106,6 @@ namespace mysql_runner
             if (start != 0)
             {
                 // naive: assumes no mid-line comments; but this is how mysqldump makes it
-                // also assumes no multi-line comments
                 return line;
             }
 
@@ -135,20 +134,22 @@ namespace mysql_runner
             }
 
             // Prevent double counting in case nothing was added to the parts
-            if (_lastBlockStartIndex == parts.Count())
+            if (_lastBlockStartIndex == parts.Count)
+            {
                 return false;
+            }
 
             var agnosticLast = last.Trim(';').Trim().ToLower();
             if (agnosticLast == "begin")
             {
-                _lastBlockStartIndex = parts.Count();
+                _lastBlockStartIndex = parts.Count;
                 _currentBlockLevel++;
                 return false;
             }
 
             if (agnosticLast == "end")
             {
-                _lastBlockStartIndex = parts.Count();
+                _lastBlockStartIndex = parts.Count;
                 _currentBlockLevel--;
                 if (_currentBlockLevel < 0)
                 {
@@ -173,7 +174,6 @@ namespace mysql_runner
             {
                 return false;
             }
-
 
             var delimiterMatches = DelimiterMatcher.Match(last);
             var delimiter = delimiterMatches.Groups

--- a/src/mysql-runner/StatementReader.cs
+++ b/src/mysql-runner/StatementReader.cs
@@ -9,18 +9,22 @@ namespace mysql_runner
     public class StatementReader : IDisposable
     {
         private StreamReader _reader;
+        private Options _opts;
         private readonly List<string> _parts = new List<string>();
         public long LastReadBytes { get; private set; }
 
-        public StatementReader(string filePath)
+        public StatementReader(string filePath, Options opts)
         {
             _reader = new StreamReader(filePath);
+            _opts = opts;
         }
 
         private static readonly Regex DelimiterMatcher = new Regex("^\\s*DELIMITER\\s*([^\\s]*)");
         private const string DEFAULT_DELIMITER = ";";
         private string _currentDelimiter = DEFAULT_DELIMITER;
         private int _currentBlockLevel = 0;
+        private int _lastBlockStartIndex = 0;
+        private bool _openComment = false;
 
         public string Next()
         {
@@ -28,6 +32,7 @@ namespace mysql_runner
             lock (_parts)
             {
                 _parts.Clear();
+                _lastBlockStartIndex = -1;
                 do
                 {
                     var line = _reader.ReadLine();
@@ -63,12 +68,41 @@ namespace mysql_runner
                 return null;
             }
 
+            var end = line.LastIndexOf("*/");
+            if (_openComment)
+            {
+                if (end == -1)
+                {
+                    return "";
+                }
+                else
+                {
+                    _openComment = false;
+                    return "";
+                }
+            }
+
             if (line.StartsWith("--"))
             {
                 return "";
             }
 
             var start = line.IndexOf("/*");
+
+            while (start > -1 && line.Length > start && _opts.IncludeMySqlSpecificComments)
+            {
+                //MySql specific comments
+                if (line[start + 2] == '!')
+                {
+                    start = line.IndexOf("/*", start + 1);
+                }
+                //Valid comment
+                else
+                {
+                    break;
+                }
+            }
+
             if (start != 0)
             {
                 // naive: assumes no mid-line comments; but this is how mysqldump makes it
@@ -76,14 +110,15 @@ namespace mysql_runner
                 return line;
             }
 
-            var end = line.LastIndexOf("*/");
             if (end == -1)
             {
-                // broken? or perhaps multi-line (not catered for)
+                //Start multi line comment
+                _openComment = true;
                 return "";
             }
 
-            return line.Substring(end + 2);
+            //Multi comments in a single line where the last comment is still open requires some recursion
+            return StripComments(line.Substring(end + 2).Trim());
         }
 
         private bool IsTerminated(List<string> parts)
@@ -99,15 +134,21 @@ namespace mysql_runner
                 return false;
             }
 
+            // Prevent double counting in case nothing was added to the parts
+            if (_lastBlockStartIndex == parts.Count())
+                return false;
+
             var agnosticLast = last.Trim(';').Trim().ToLower();
             if (agnosticLast == "begin")
             {
+                _lastBlockStartIndex = parts.Count();
                 _currentBlockLevel++;
                 return false;
             }
 
             if (agnosticLast == "end")
             {
+                _lastBlockStartIndex = parts.Count();
                 _currentBlockLevel--;
                 if (_currentBlockLevel < 0)
                 {


### PR DESCRIPTION
Fixes the following issues

- Begin/End blocks followed by a comment or other non-statements are interpreted correctly
- Allows multi-line comments
- Fixes an issue where comments preceding a multi-line comment isn't closed out
- Added an option to run MySql specific comments (such as trigger creation)